### PR TITLE
Replace EJS with Lodash templates and improve minification

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,12 +15,12 @@
         "@eslint/js": "^9.28.0",
         "@vitest/coverage-v8": "^3.2.3",
         "@vitest/ui": "^3.2.3",
-        "ejs": "^3.1.10",
         "eslint": "^9.28.0",
         "eslint-config-prettier": "^10.1.5",
         "eslint-plugin-prettier": "^5.4.1",
         "happy-dom": "^20.0.0",
         "jszip": "^3.10.1",
+        "lodash": "^4.18.1",
         "prettier": "^3.5.3",
         "rimraf": "^6.0.0",
         "terser": "^5.42.0",
@@ -30,7 +30,6 @@
         "vitest": "^3.2.3"
       },
       "peerDependencies": {
-        "ejs": "^3.1.10",
         "jszip": "^3.10.1"
       }
     },
@@ -1634,13 +1633,6 @@
         "js-tokens": "^9.0.1"
       }
     },
-    "node_modules/async": {
-      "version": "3.2.6",
-      "resolved": "https://registry.npmjs.org/async/-/async-3.2.6.tgz",
-      "integrity": "sha512-htCUDlxyyCLMgaM3xXg0C0LW2xqfuQ6p05pCEIsXuyQ+a1koYKTuBMzRNwmybfLgvJDMd0r1LTn4+E0Ti6C2AA==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/available-typed-arrays": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.7.tgz",
@@ -2330,22 +2322,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/ejs": {
-      "version": "3.1.10",
-      "resolved": "https://registry.npmjs.org/ejs/-/ejs-3.1.10.tgz",
-      "integrity": "sha512-UeJmFfOrAQS8OJWPZ4qtgHyWExa088/MtK5UEyoJGFH67cDEXkZSviOiKRCZ4Xij0zxI3JECgYs3oKx+AizQBA==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "jake": "^10.8.5"
-      },
-      "bin": {
-        "ejs": "bin/cli.js"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/elliptic": {
       "version": "6.6.1",
       "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.6.1.tgz",
@@ -2791,39 +2767,6 @@
       },
       "engines": {
         "node": ">=16.0.0"
-      }
-    },
-    "node_modules/filelist": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/filelist/-/filelist-1.0.4.tgz",
-      "integrity": "sha512-w1cEuf3S+DrLCQL7ET6kz+gmlJdbq9J7yXCSjK/OZCPA+qEN1WyF4ZAf0YYJa4/shHJra2t/d/r8SV4Ji+x+8Q==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "minimatch": "^5.0.1"
-      }
-    },
-    "node_modules/filelist/node_modules/brace-expansion": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
-      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^1.0.0"
-      }
-    },
-    "node_modules/filelist/node_modules/minimatch": {
-      "version": "5.1.9",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.9.tgz",
-      "integrity": "sha512-7o1wEA2RyMP7Iu7GNba9vc0RWWGACJOCZBJX2GJWip0ikV+wcOsgVuY9uE8CPiyQhkGFSlhuSkZPavN7u1c2Fw==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "brace-expansion": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=10"
       }
     },
     "node_modules/find-up": {
@@ -3546,24 +3489,6 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
-    "node_modules/jake": {
-      "version": "10.9.4",
-      "resolved": "https://registry.npmjs.org/jake/-/jake-10.9.4.tgz",
-      "integrity": "sha512-wpHYzhxiVQL+IV05BLE2Xn34zW1S223hvjtqk0+gsPrwd/8JNLXJgZZM/iPFsYc1xyphF+6M6EvdE5E9MBGkDA==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "async": "^3.2.6",
-        "filelist": "^1.0.4",
-        "picocolors": "^1.1.1"
-      },
-      "bin": {
-        "jake": "bin/cli.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/js-tokens": {
       "version": "9.0.1",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-9.0.1.tgz",
@@ -3667,6 +3592,13 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/lodash": {
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/lodash.merge": {
       "version": "4.6.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,6 +21,7 @@
         "happy-dom": "^20.0.0",
         "jszip": "^3.10.1",
         "lodash": "^4.18.1",
+        "minify-xml": "^4.5.2",
         "prettier": "^3.5.3",
         "rimraf": "^6.0.0",
         "terser": "^5.42.0",
@@ -2315,6 +2316,34 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/duplexify": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/duplexify/-/duplexify-4.1.3.tgz",
+      "integrity": "sha512-M3BmBhwJRZsSx38lZyhE53Csddgzl5R7xGJNk7CVddZD6CcmwMCH8J+7AprIrQKH7TonKxaCjcv27Qmf+sQ+oA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "end-of-stream": "^1.4.1",
+        "inherits": "^2.0.3",
+        "readable-stream": "^3.1.1",
+        "stream-shift": "^1.0.2"
+      }
+    },
+    "node_modules/duplexify/node_modules/readable-stream": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/eastasianwidth": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
@@ -2351,6 +2380,16 @@
       "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/end-of-stream": {
+      "version": "1.4.5",
+      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz",
+      "integrity": "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "once": "^1.4.0"
+      }
     },
     "node_modules/entities": {
       "version": "7.0.1",
@@ -3684,6 +3723,19 @@
         "safe-buffer": "^5.1.2"
       }
     },
+    "node_modules/meow": {
+      "version": "13.2.0",
+      "resolved": "https://registry.npmjs.org/meow/-/meow-13.2.0.tgz",
+      "integrity": "sha512-pxQJQzB6djGPXh08dacEloMFopsOqGVRKFPYvPOt9XDZ1HasbgDZA74CJGreSU4G3Ak7EFJGoiH2auq+yXISgA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/miller-rabin": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/miller-rabin/-/miller-rabin-4.0.1.tgz",
@@ -3704,6 +3756,24 @@
       "integrity": "sha512-n4DSx829VRTRByMRGdjQ9iqsN0Bh4OolPsFnaZBLcbi8iXcB+kJ9s7EnRt4wILZNV3kPLHkRVfOc/HvhC3ovDw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/minify-xml": {
+      "version": "4.5.2",
+      "resolved": "https://registry.npmjs.org/minify-xml/-/minify-xml-4.5.2.tgz",
+      "integrity": "sha512-iPNfX4n7pgJc3VFcf/Fbuzxdh2V8zNc8pLezVTLWJVxk8G/qmMijtgr7OkT5VAAGhWeIxpVH+WwgvigfF/6bZQ==",
+      "dev": true,
+      "license": "(MIT OR Apache-2.0)",
+      "dependencies": {
+        "meow": "^13.2.0",
+        "pumpify": "^2.0.1",
+        "replacestream": "^4.0.3"
+      },
+      "bin": {
+        "minify-xml": "cli.js"
+      },
+      "engines": {
+        "node": ">=16"
+      }
     },
     "node_modules/minimalistic-assert": {
       "version": "1.0.1",
@@ -3846,6 +3916,16 @@
         "node": ">= 6"
       }
     },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/object-inspect": {
       "version": "1.13.4",
       "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
@@ -3905,6 +3985,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "wrappy": "1"
       }
     },
     "node_modules/optionator": {
@@ -4286,6 +4376,29 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/pump": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.4.tgz",
+      "integrity": "sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "end-of-stream": "^1.1.0",
+        "once": "^1.3.1"
+      }
+    },
+    "node_modules/pumpify": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/pumpify/-/pumpify-2.0.1.tgz",
+      "integrity": "sha512-m7KOje7jZxrmutanlkS1daj1dS6z6BgslzOXmcSEpIlCxM3VJH7lG5QLeck/6hgF6F4crFf01UtQmNsJfweTAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "duplexify": "^4.1.1",
+        "inherits": "^2.0.3",
+        "pump": "^3.0.0"
+      }
+    },
     "node_modules/punycode": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
@@ -4356,6 +4469,28 @@
         "safe-buffer": "~5.1.1",
         "string_decoder": "~1.1.1",
         "util-deprecate": "~1.0.1"
+      }
+    },
+    "node_modules/replacestream": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/replacestream/-/replacestream-4.0.3.tgz",
+      "integrity": "sha512-AC0FiLS352pBBiZhd4VXB1Ab/lh0lEgpP+GGvZqbQh8a5cmXVoTe5EX/YeTFArnp4SRGTHh1qCHu9lGs1qG8sA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "escape-string-regexp": "^1.0.3",
+        "object-assign": "^4.0.1",
+        "readable-stream": "^2.0.2"
+      }
+    },
+    "node_modules/replacestream/node_modules/escape-string-regexp": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+      "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8.0"
       }
     },
     "node_modules/resolve": {
@@ -4842,6 +4977,13 @@
       "engines": {
         "node": ">= 6"
       }
+    },
+    "node_modules/stream-shift": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/stream-shift/-/stream-shift-1.0.3.tgz",
+      "integrity": "sha512-76ORR0DO1o1hlKwTbi/DM3EXWGf3ZJYO8cXX5RJwnul2DEg2oyoZyjLNoQM8WsvZiFKCRfC1O0J7iCvie3RZmQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/string_decoder": {
       "version": "1.1.1",
@@ -5739,6 +5881,13 @@
       "funding": {
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/ws": {
       "version": "8.20.0",

--- a/package.json
+++ b/package.json
@@ -49,19 +49,18 @@
     "@xmldom/xmldom": "^0.8.11"
   },
   "peerDependencies": {
-    "ejs": "^3.1.10",
     "jszip": "^3.10.1"
   },
   "devDependencies": {
     "@eslint/js": "^9.28.0",
     "@vitest/coverage-v8": "^3.2.3",
     "@vitest/ui": "^3.2.3",
-    "ejs": "^3.1.10",
     "eslint": "^9.28.0",
     "eslint-config-prettier": "^10.1.5",
     "eslint-plugin-prettier": "^5.4.1",
     "happy-dom": "^20.0.0",
     "jszip": "^3.10.1",
+    "lodash": "^4.18.1",
     "prettier": "^3.5.3",
     "rimraf": "^6.0.0",
     "terser": "^5.42.0",

--- a/package.json
+++ b/package.json
@@ -61,6 +61,7 @@
     "happy-dom": "^20.0.0",
     "jszip": "^3.10.1",
     "lodash": "^4.18.1",
+    "minify-xml": "^4.5.2",
     "prettier": "^3.5.3",
     "rimraf": "^6.0.0",
     "terser": "^5.42.0",

--- a/src/jepub.js
+++ b/src/jepub.js
@@ -241,11 +241,8 @@ export default class jEpub {
             const images = this._Images;
             const fallback =
                 'data:image/gif;base64,R0lGODlhAQABAIAAAAUEBAAAACwAAAAAAQABAAACAkQBADs=';
-            content = content.replace(/<%=([\s\S]*?)%>/g, (_, expr) => {
-                const img = new Function(
-                    'image',
-                    `return (${expr.trim()})`
-                ).call(null, images);
+            content = content.replace(/<%=[\s]*image\[['"]([\S]*?)['"]\][\s]*%>/g, (_, expr) => {
+                const img = images[expr.trim()];
                 return `<img src="${img ? img.path : fallback}" alt=""></img>`;
             });
             content = utils.parseDOM(content);

--- a/src/jepub.js
+++ b/src/jepub.js
@@ -1,22 +1,20 @@
 'use strict';
 
 import JSZip from 'jszip';
-import ejs from 'ejs';
 import * as utils from './utils/index.js';
 import { detectImageType } from './utils/mime.js';
 
 import language from './i18n.json';
 
-// Template imports using Vite's native ?raw suffix for text content
 import container from './tpl/META-INF/container.xml?raw';
-import cover from './tpl/OEBPS/front-cover.html.ejs?raw';
-import notes from './tpl/OEBPS/notes.html.ejs?raw';
-import page from './tpl/OEBPS/page.html.ejs?raw';
-import tocInBook from './tpl/OEBPS/table-of-contents.html.ejs?raw';
-import info from './tpl/OEBPS/title-page.html.ejs?raw';
-import bookConfig from './tpl/book.opf.ejs?raw';
 import mime from './tpl/mimetype?raw';
-import toc from './tpl/toc.ncx.ejs?raw';
+import renderCover from './tpl/OEBPS/front-cover.html.ejs';
+import renderNotes from './tpl/OEBPS/notes.html.ejs';
+import renderPage from './tpl/OEBPS/page.html.ejs';
+import renderTocInBook from './tpl/OEBPS/table-of-contents.html.ejs';
+import renderInfo from './tpl/OEBPS/title-page.html.ejs';
+import renderBookConfig from './tpl/book.opf.ejs';
+import renderToc from './tpl/toc.ncx.ejs';
 
 export default class jEpub {
     constructor() {
@@ -72,20 +70,14 @@ export default class jEpub {
         this._Zip.file('META-INF/container.xml', container);
         this._Zip.file(
             'OEBPS/title-page.html',
-            ejs.render(
-                info,
-                {
-                    i18n: this._I18n,
-                    title: this._Info.title,
-                    author: this._Info.author,
-                    publisher: this._Info.publisher,
-                    description: utils.parseDOM(this._Info.description),
-                    tags: this._Info.tags,
-                },
-                {
-                    client: true,
-                }
-            )
+            renderInfo({
+                i18n: this._I18n,
+                title: this._Info.title,
+                author: this._Info.author,
+                publisher: this._Info.publisher,
+                description: utils.parseDOM(this._Info.description),
+                tags: this._Info.tags,
+            })
         );
 
         return this;
@@ -165,16 +157,10 @@ export default class jEpub {
         this._Zip.file(this._Cover.path, data);
         this._Zip.file(
             'OEBPS/front-cover.html',
-            ejs.render(
-                cover,
-                {
-                    i18n: this._I18n,
-                    cover: this._Cover,
-                },
-                {
-                    client: true,
-                }
-            )
+            renderCover({
+                i18n: this._I18n,
+                cover: this._Cover,
+            })
         );
         return this;
     }
@@ -221,16 +207,10 @@ export default class jEpub {
         } else {
             this._Zip.file(
                 'OEBPS/notes.html',
-                ejs.render(
-                    notes,
-                    {
-                        i18n: this._I18n,
-                        notes: utils.parseDOM(content),
-                    },
-                    {
-                        client: true,
-                    }
-                )
+                renderNotes({
+                    i18n: this._I18n,
+                    notes: utils.parseDOM(content),
+                })
             );
             return this;
         }
@@ -258,38 +238,27 @@ export default class jEpub {
         }
 
         if (content && !Array.isArray(content)) {
-            const template = ejs.compile(content, {
-                client: true,
+            const images = this._Images;
+            const fallback =
+                'data:image/gif;base64,R0lGODlhAQABAIAAAAUEBAAAACwAAAAAAQABAAACAkQBADs=';
+            content = content.replace(/<%=([\s\S]*?)%>/g, (_, expr) => {
+                const img = new Function(
+                    'image',
+                    `return (${expr.trim()})`
+                ).call(null, images);
+                return `<img src="${img ? img.path : fallback}" alt=""></img>`;
             });
-            content = template(
-                {
-                    image: this._Images,
-                },
-                (data) => {
-                    return `<img src="${
-                        data
-                            ? data.path
-                            : 'data:image/gif;base64,R0lGODlhAQABAIAAAAUEBAAAACwAAAAAAQABAAACAkQBADs='
-                    }" alt=""></img>`;
-                }
-            );
             content = utils.parseDOM(content);
         }
 
         const pageId = this._Pages.length;
         this._Zip.file(
             `OEBPS/page-${pageId}.html`,
-            ejs.render(
-                page,
-                {
-                    i18n: this._I18n,
-                    title,
-                    content,
-                },
-                {
-                    client: true,
-                }
-            )
+            renderPage({
+                i18n: this._I18n,
+                title,
+                content,
+            })
         );
         this._Pages.push({
             title,
@@ -313,58 +282,40 @@ export default class jEpub {
 
         this._Zip.file(
             'book.opf',
-            ejs.render(
-                bookConfig,
-                {
-                    i18n: this._I18n,
-                    uuid: this._Uuid,
-                    date: this._Date,
-                    title: this._Info.title,
-                    author: this._Info.author,
-                    publisher: this._Info.publisher,
-                    description: utils.html2text(this._Info.description, true),
-                    tags: this._Info.tags,
-                    cover: this._Cover,
-                    pages: this._Pages,
-                    notes,
-                    images: this._Images,
-                },
-                {
-                    client: true,
-                }
-            )
+            renderBookConfig({
+                i18n: this._I18n,
+                uuid: this._Uuid,
+                date: this._Date,
+                title: this._Info.title,
+                author: this._Info.author,
+                publisher: this._Info.publisher,
+                description: utils.html2text(this._Info.description, true),
+                tags: this._Info.tags,
+                cover: this._Cover,
+                pages: this._Pages,
+                notes,
+                images: this._Images,
+            })
         );
 
         this._Zip.file(
             'OEBPS/table-of-contents.html',
-            ejs.render(
-                tocInBook,
-                {
-                    i18n: this._I18n,
-                    pages: this._Pages,
-                },
-                {
-                    client: true,
-                }
-            )
+            renderTocInBook({
+                i18n: this._I18n,
+                pages: this._Pages,
+            })
         );
 
         this._Zip.file(
             'toc.ncx',
-            ejs.render(
-                toc,
-                {
-                    i18n: this._I18n,
-                    uuid: this._Uuid,
-                    title: this._Info.title,
-                    author: this._Info.author,
-                    pages: this._Pages,
-                    notes,
-                },
-                {
-                    client: true,
-                }
-            )
+            renderToc({
+                i18n: this._I18n,
+                uuid: this._Uuid,
+                title: this._Info.title,
+                author: this._Info.author,
+                pages: this._Pages,
+                notes,
+            })
         );
 
         return this._Zip.generateAsync(

--- a/src/tpl/OEBPS/front-cover.html.ejs
+++ b/src/tpl/OEBPS/front-cover.html.ejs
@@ -1,15 +1,15 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.1//EN" "http://www.w3.org/TR/xhtml11/DTD/xhtml11.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="<%= i18n.code %>">
+<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="<%= data.i18n.code %>">
 
 <head>
-	<title><%= i18n.cover %></title>
+	<title><%= data.i18n.cover %></title>
 	<meta http-equiv="Content-Type" content="application/xhtml+xml; charset=utf-8" />
 </head>
 
 <body>
 	<div id="cover-image">
-		<img src="../<%= cover.path %>" alt="<%= i18n.cover %>" />
+		<img src="../<%= data.cover.path %>" alt="<%= data.i18n.cover %>" />
 	</div>
 </body>
 

--- a/src/tpl/OEBPS/notes.html.ejs
+++ b/src/tpl/OEBPS/notes.html.ejs
@@ -1,16 +1,16 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.1//EN" "http://www.w3.org/TR/xhtml11/DTD/xhtml11.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="<%= i18n.code %>">
+<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="<%= data.i18n.code %>">
 
 <head>
-	<title><%= i18n.note %></title>
+	<title><%= data.i18n.note %></title>
 	<meta http-equiv="Content-Type" content="application/xhtml+xml; charset=utf-8" />
 </head>
 
 <body>
 	<div id="notes-page">
 		<div class="ugc">
-            <%- notes %>
+            <%- data.notes %>
 		</div>
 	</div>
 </body>

--- a/src/tpl/OEBPS/page.html.ejs
+++ b/src/tpl/OEBPS/page.html.ejs
@@ -1,25 +1,25 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.1//EN" "http://www.w3.org/TR/xhtml11/DTD/xhtml11.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="<%= i18n.code %>">
+<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="<%= data.i18n.code %>">
 
 <head>
-	<title><%= title %></title>
+	<title><%= data.title %></title>
 	<meta http-equiv="Content-Type" content="application/xhtml+xml; charset=utf-8" />
 </head>
 
 <body>
 	<div class="chapter type-1">
 		<div class="chapter-title-wrap">
-			<h2 class="chapter-title"><%= title %></h2>
+			<h2 class="chapter-title"><%= data.title %></h2>
 		</div>
-        <% if (content) { %>
+        <% if (data.content) { %>
             <div class="ugc chapter-ugc">
-                <% if (Array.isArray(content)) { %>
-                    <% content.forEach(item => { %>
+                <% if (Array.isArray(data.content)) { %>
+                    <% data.content.forEach(item => { %>
                         <p class="indent"><%= item %></p>
                     <% }); %>
                 <% } else { %>
-                    <%- content %>
+                    <%- data.content %>
                 <% } %>
             </div>
         <% } %>

--- a/src/tpl/OEBPS/table-of-contents.html.ejs
+++ b/src/tpl/OEBPS/table-of-contents.html.ejs
@@ -1,18 +1,18 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.1//EN" "http://www.w3.org/TR/xhtml11/DTD/xhtml11.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="<%= i18n.code %>">
+<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="<%= data.i18n.code %>">
 
 <head>
-	<title><%= i18n.toc %></title>
+	<title><%= data.i18n.toc %></title>
 	<meta http-equiv="Content-Type" content="application/xhtml+xml; charset=utf-8" />
 </head>
 
 <body>
 	<div id="toc">
-		<h1><%= i18n.toc %></h1>
+		<h1><%= data.i18n.toc %></h1>
 		<ul>
             <% let currentLevel = 0; %>
-            <% pages.forEach(({title,level}, index) => { %>
+            <% data.pages.forEach(({title,level}, index) => { %>
                 <% if (level > currentLevel) { %>
                     <ul>
                 <% } %>

--- a/src/tpl/OEBPS/title-page.html.ejs
+++ b/src/tpl/OEBPS/title-page.html.ejs
@@ -1,28 +1,28 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.1//EN" "http://www.w3.org/TR/xhtml11/DTD/xhtml11.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="<%= i18n.code %>">
+<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="<%= data.i18n.code %>">
 
 <head>
-	<title><%= i18n.info %></title>
+	<title><%= data.i18n.info %></title>
 	<meta http-equiv="Content-Type" content="application/xhtml+xml; charset=utf-8" />
 </head>
 
 <body>
 	<div id="title-page">
-		<h1 class="title"><%= title %></h1>
+		<h1 class="title"><%= data.title %></h1>
 		<h2 class="subtitle"></h2>
-		<h3 class="author"><%= author %></h3>
-		<h4 class="publisher"><%= publisher %></h4>
+		<h3 class="author"><%= data.author %></h3>
+		<h4 class="publisher"><%= data.publisher %></h4>
 	</div>
-    <% if (Array.isArray(tags) && tags.length) { %>
+    <% if (Array.isArray(data.tags) && data.tags.length) { %>
         <div class="part-title-wrap">
-            <% tags = tags.join('</code>, <code>'); %>
+            <% const tags = data.tags.join('</code>, <code>'); %>
             <code><%- tags %></code>
         </div>
     <% } %>
-    <% if (description) { %>
+    <% if (data.description) { %>
         <div class="ugc">
-            <%- description %>
+            <%- data.description %>
         </div>
     <% } %>
 </body>

--- a/src/tpl/book.opf.ejs
+++ b/src/tpl/book.opf.ejs
@@ -2,61 +2,61 @@
 <package version="2.0" xmlns="http://www.idpf.org/2007/opf" unique-identifier="PrimaryID">
 
 	<metadata xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:opf="http://www.idpf.org/2007/opf">
-		<dc:title><%= title %></dc:title>
-		<dc:language><%= i18n.code %></dc:language>
-		<dc:identifier id="PrimaryID" opf:scheme="<%= uuid.scheme %>"><%= uuid.id %></dc:identifier>
-        <dc:date opf:event="publication"><%= date %></dc:date>
-        <% if (description) { %>
-		    <dc:description><%= description %></dc:description>
+		<dc:title><%= data.title %></dc:title>
+		<dc:language><%= data.i18n.code %></dc:language>
+		<dc:identifier id="PrimaryID" opf:scheme="<%= data.uuid.scheme %>"><%= data.uuid.id %></dc:identifier>
+        <dc:date opf:event="publication"><%= data.date %></dc:date>
+        <% if (data.description) { %>
+		    <dc:description><%= data.description %></dc:description>
         <% } %>
-		<dc:creator opf:role="aut"><%= author %></dc:creator>
-		<dc:publisher><%= publisher %></dc:publisher>
-        <% if (cover) { %>
+		<dc:creator opf:role="aut"><%= data.author %></dc:creator>
+		<dc:publisher><%= data.publisher %></dc:publisher>
+        <% if (data.cover) { %>
 		    <meta name="cover" content="cover-image" />
         <% } %>
-        <% if (Array.isArray(tags) && tags.length) tags.forEach(tag => { %>
+        <% if (Array.isArray(data.tags) && data.tags.length) data.tags.forEach(tag => { %>
             <dc:subject><%= tag %></dc:subject>
         <% }); %>
 	</metadata>
 
 	<manifest>
-        <% if (cover) { %>
+        <% if (data.cover) { %>
 		    <item id="front-cover" href="OEBPS/front-cover.html" media-type="application/xhtml+xml" />
         <% } %>
 		<item id="title-page" href="OEBPS/title-page.html" media-type="application/xhtml+xml" />
 		<item id="notes" href="OEBPS/notes.html" media-type="application/xhtml+xml" />
 		<item id="table-of-contents" href="OEBPS/table-of-contents.html" media-type="application/xhtml+xml" />
-        <% pages.forEach((page, index) => { %>
+        <% data.pages.forEach((page, index) => { %>
             <item id="page-<%= index %>" href="OEBPS/page-<%= index %>.html" media-type="application/xhtml+xml" />
         <% }); %>
-        <% if (cover) { %>
-		    <item id="cover-image" href="<%= cover.path %>" media-type="<%= cover.type %>" />
+        <% if (data.cover) { %>
+		    <item id="cover-image" href="<%= data.cover.path %>" media-type="<%= data.cover.type %>" />
         <% } %>
 		<item id="ncx" href="toc.ncx" media-type="application/x-dtbncx+xml" />
-        <% Object.keys(images).forEach(name => { %>
-            <item id="<%= name %>" href="OEBPS/<%= images[name].path %>" media-type="<%= images[name].type %>" />
+        <% Object.keys(data.images).forEach(name => { %>
+            <item id="<%= name %>" href="OEBPS/<%= data.images[name].path %>" media-type="<%= data.images[name].type %>" />
         <% }); %>
 	</manifest>
 
 	<spine toc="ncx">
-        <% if (cover) { %>
+        <% if (data.cover) { %>
 		    <itemref idref="front-cover" linear="no" />
         <% } %>
 		<itemref idref="title-page" linear="yes" />
 		<itemref idref="table-of-contents" linear="yes" />
-        <% pages.forEach((page, index) => { %>
+        <% data.pages.forEach((page, index) => { %>
             <itemref idref="page-<%= index %>" linear="yes" />
         <% }); %>
-        <% if (notes) { %>
+        <% if (data.notes) { %>
             <itemref idref="notes" linear="yes" />
         <% } %>
 	</spine>
 
 	<guide>
-        <% if (cover) { %>
-		    <reference type="cover" title="<%= i18n.cover %>" href="OEBPS/front-cover.html" />
+        <% if (data.cover) { %>
+		    <reference type="cover" title="<%= data.i18n.cover %>" href="OEBPS/front-cover.html" />
         <% } %>
-		<reference type="toc" title="<%= i18n.toc %>" href="OEBPS/table-of-contents.html" />
+		<reference type="toc" title="<%= data.i18n.toc %>" href="OEBPS/table-of-contents.html" />
 	</guide>
 
 </package>

--- a/src/tpl/toc.ncx.ejs
+++ b/src/tpl/toc.ncx.ejs
@@ -1,37 +1,37 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <!DOCTYPE ncx PUBLIC "-//NISO//DTD ncx 2005-1//EN" "http://www.daisy.org/z3986/2005/ncx-2005-1.dtd">
 
-<ncx version="2005-1" xml:lang="<%= i18n.code %>" xmlns="http://www.daisy.org/z3986/2005/ncx/">
+<ncx version="2005-1" xml:lang="<%= data.i18n.code %>" xmlns="http://www.daisy.org/z3986/2005/ncx/">
 	<head>
-		<meta name="dtb:uid" content="<%= uuid.id %>" />
+		<meta name="dtb:uid" content="<%= data.uuid.id %>" />
 		<meta name="dtb:depth" content="2" />
 		<meta name="dtb:totalPageCount" content="0" />
 		<meta name="dtb:maxPageNumber" content="0" />
 	</head>
 
 	<docTitle>
-		<text><%= title %></text>
+		<text><%= data.title %></text>
 	</docTitle>
 
 	<docAuthor>
-		<text><%= author %></text>
+		<text><%= data.author %></text>
 	</docAuthor>
 
 	<navMap>
 		<navPoint id="title-page" playOrder="1">
 			<navLabel>
-				<text><%= i18n.info %></text>
+				<text><%= data.i18n.info %></text>
 			</navLabel>
 			<content src="OEBPS/title-page.html" />
 		</navPoint>
 		<navPoint id="table-of-contents" playOrder="2">
 			<navLabel>
-				<text><%= i18n.toc %></text>
+				<text><%= data.i18n.toc %></text>
 			</navLabel>
 			<content src="OEBPS/table-of-contents.html" />
 		</navPoint>
         <% let currentLevel = -1; %>
-        <% pages.forEach(({title,level}, index) => { %>
+        <% data.pages.forEach(({title,level}, index) => { %>
             <% if (level <= currentLevel) { %>
                 <% for (let i = currentLevel; i >= level; i--) { %>
                     </navPoint>
@@ -49,10 +49,10 @@
                 </navPoint>
             <% } %>
         <% } %>
-        <% if (notes) { %>
+        <% if (data.notes) { %>
             <navPoint id="notes-page" playOrder="2">
                 <navLabel>
-                    <text><%= i18n.note %></text>
+                    <text><%= data.i18n.note %></text>
                 </navLabel>
                 <content src="OEBPS/notes.html" />
             </navPoint>

--- a/test/errors.test.js
+++ b/test/errors.test.js
@@ -160,13 +160,6 @@ describe('jEpub Error Handling', () => {
             expect(() => epub.add('Title', '   ')).not.toThrow();
             expect(() => epub.add('Title', null)).not.toThrow();
         });
-        it('should handle invalid template content gracefully', () => {
-            // Template with undefined variable - EJS will throw ReferenceError
-            const invalidTemplate = '<p>Hello <%= valid_syntax %></p>';
-            expect(() => epub.add('Test', invalidTemplate)).toThrow(
-                /valid_syntax is not defined|ReferenceError/
-            );
-        });
     });
 
     describe('Generation Errors', () => {

--- a/vite-plugin-ejs-precompile.js
+++ b/vite-plugin-ejs-precompile.js
@@ -1,16 +1,40 @@
 import lodash from 'lodash';
+import minifyXML from "minify-xml";
 const { template: lodashTemplate } = lodash;
 
 const HTML_ESCAPE_FN = `function escapeFallback(s){var m={'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;',"'":'&#39;'};return s==null?'':String(s).replace(/[&<>"']/g,function(c){return m[c];});}`;
+const XML_PROLOG_REGEX = /(<\?xml\s*version="1.0"\s*encoding="UTF-8"\s*\?>)\s*/;
+const XHTML_DOCTYPE_REGEX = /(<!DOCTYPE\s*html\s*PUBLIC\s*"-\/\/W3C\/\/DTD\s*XHTML\s*1\.1\/\/EN"\s*"http:\/\/www\.w3\.org\/TR\/xhtml11\/DTD\/xhtml11\.dtd">)\s*/;
 
 export function ejsPrecompile() {
     return {
         name: 'ejs-precompile',
         enforce: 'pre',
-        transform(src, id) {
-            if (!id.endsWith('.ejs')) return null;
+        transform(template, filename) {
+            if (!filename.endsWith('.ejs')) {
+                return null;
+            }
 
-            const compiled = lodashTemplate(src, {
+            if (
+                (filename.endsWith('.html.ejs')) ||
+                (filename.endsWith('.opf.ejs')) ||
+                (filename.endsWith('.ncx.ejs'))
+            ) {
+                template = minifyXML(template, {
+                    collapseEmptyElements: false,
+                    collapseWhitespaceInProlog: false,
+                    collapseWhitespaceInDocType: false,
+                    removeUnnecessaryStandaloneDeclaration: false,
+                    removeUnusedNamespaces: false,
+                    removeUnusedDefaultNamespace: false,
+                    shortenNamespaces: false,
+                });
+                template = template
+                    .replace(XML_PROLOG_REGEX, (_, expr) => `${expr}\n`)
+                    .replace(XHTML_DOCTYPE_REGEX, (_, expr) => `${expr}\n`);
+            }
+
+            const compiled = lodashTemplate(template, {
                 // Match EJS semantics: <%= %> is escaped, <%- %> is raw
                 escape: /<%=([\s\S]+?)%>/g,
                 interpolate: /<%-([^>]+?)%>/g,

--- a/vite-plugin-ejs-precompile.js
+++ b/vite-plugin-ejs-precompile.js
@@ -2,9 +2,9 @@ import lodash from 'lodash';
 import minifyXML from "minify-xml";
 const { template: lodashTemplate } = lodash;
 
-const HTML_ESCAPE_FN = `function escapeFallback(s){var m={'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;',"'":'&#39;'};return s==null?'':String(s).replace(/[&<>"']/g,function(c){return m[c];});}`;
+const ESCAPE_FALLBACK = `function escapeFallback(s){var m={'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;',"'":'&#39;'};return s==null?'':String(s).replace(/[&<>"']/g,function(c){return m[c];});}`;
 const XML_PROLOG_REGEX = /(<\?xml\s*version="1.0"\s*encoding="UTF-8"\s*\?>)\s*/;
-const XHTML_DOCTYPE_REGEX = /(<!DOCTYPE\s*html\s*PUBLIC\s*"-\/\/W3C\/\/DTD\s*XHTML\s*1\.1\/\/EN"\s*"http:\/\/www\.w3\.org\/TR\/xhtml11\/DTD\/xhtml11\.dtd">)\s*/;
+const XML_DOCTYPE_REGEX = /(<!DOCTYPE\s*html\s*PUBLIC\s*"-\/\/W3C\/\/DTD\s*XHTML\s*1\.1\/\/EN"\s*"http:\/\/www\.w3\.org\/TR\/xhtml11\/DTD\/xhtml11\.dtd">)\s*/;
 
 export function ejsPrecompile() {
     return {
@@ -31,7 +31,7 @@ export function ejsPrecompile() {
                 });
                 template = template
                     .replace(XML_PROLOG_REGEX, (_, expr) => `${expr}\n`)
-                    .replace(XHTML_DOCTYPE_REGEX, (_, expr) => `${expr}\n`);
+                    .replace(XML_DOCTYPE_REGEX, (_, expr) => `${expr}\n`);
             }
 
             const compiled = lodashTemplate(template, {
@@ -46,7 +46,7 @@ export function ejsPrecompile() {
                 .replace('_.escape', `escapeFallback`);
 
             return {
-                code: `${HTML_ESCAPE_FN};export default ${body};`,
+                code: `${ESCAPE_FALLBACK};export default ${body};`,
                 map: null,
             };
         },

--- a/vite-plugin-ejs-precompile.js
+++ b/vite-plugin-ejs-precompile.js
@@ -1,7 +1,7 @@
 import lodash from 'lodash';
 const { template: lodashTemplate } = lodash;
 
-const HTML_ESCAPE_FN = `function(s){var m={'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;',"'":'&#39;'};return s==null?'':String(s).replace(/[&<>"']/g,function(c){return m[c];});}`;
+const HTML_ESCAPE_FN = `function escapeFallback(s){var m={'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;',"'":'&#39;'};return s==null?'':String(s).replace(/[&<>"']/g,function(c){return m[c];});}`;
 
 export function ejsPrecompile() {
     return {
@@ -15,17 +15,14 @@ export function ejsPrecompile() {
                 escape: /<%=([\s\S]+?)%>/g,
                 interpolate: /<%-([^>]+?)%>/g,
                 evaluate: /<%(?![=-])([\s\S]+?)%>/g,
+                variable: 'data',
             });
 
-            // Extract function body (strip outer "function(obj){" and closing "}")
-            // Use new Function so the with-statement works outside strict mode
             const body = compiled.source
-                .replace(/^[^{]+\{/, '')
-                .replace(/\}\s*$/, '')
-                .replace('_.escape', `(${HTML_ESCAPE_FN})`);
+                .replace('_.escape', `escapeFallback`);
 
             return {
-                code: `export default new Function('obj', ${JSON.stringify(body)});`,
+                code: `${HTML_ESCAPE_FN};export default ${body};`,
                 map: null,
             };
         },

--- a/vite-plugin-ejs-precompile.js
+++ b/vite-plugin-ejs-precompile.js
@@ -1,0 +1,33 @@
+import lodash from 'lodash';
+const { template: lodashTemplate } = lodash;
+
+const HTML_ESCAPE_FN = `function(s){var m={'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;',"'":'&#39;'};return s==null?'':String(s).replace(/[&<>"']/g,function(c){return m[c];});}`;
+
+export function ejsPrecompile() {
+    return {
+        name: 'ejs-precompile',
+        enforce: 'pre',
+        transform(src, id) {
+            if (!id.endsWith('.ejs')) return null;
+
+            const compiled = lodashTemplate(src, {
+                // Match EJS semantics: <%= %> is escaped, <%- %> is raw
+                escape: /<%=([\s\S]+?)%>/g,
+                interpolate: /<%-([^>]+?)%>/g,
+                evaluate: /<%(?![=-])([\s\S]+?)%>/g,
+            });
+
+            // Extract function body (strip outer "function(obj){" and closing "}")
+            // Use new Function so the with-statement works outside strict mode
+            const body = compiled.source
+                .replace(/^[^{]+\{/, '')
+                .replace(/\}\s*$/, '')
+                .replace('_.escape', `(${HTML_ESCAPE_FN})`);
+
+            return {
+                code: `export default new Function('obj', ${JSON.stringify(body)});`,
+                map: null,
+            };
+        },
+    };
+}

--- a/vite.config.js
+++ b/vite.config.js
@@ -4,6 +4,7 @@ import { fileURLToPath } from 'url';
 import { readFileSync } from 'fs';
 import banner from 'vite-plugin-banner';
 import { nodePolyfills } from 'vite-plugin-node-polyfills';
+import { ejsPrecompile } from './vite-plugin-ejs-precompile.js';
 
 const __dirname = fileURLToPath(new URL('.', import.meta.url));
 const PACKAGE = JSON.parse(
@@ -22,11 +23,10 @@ export default defineConfig({
         },
 
         rollupOptions: {
-            external: ['jszip', 'ejs'], // Externalize dependencies
+            external: ['jszip'],
             output: {
                 globals: {
                     jszip: 'JSZip',
-                    ejs: 'ejs',
                 },
             },
             onwarn(warning, warn) {
@@ -66,6 +66,7 @@ export default defineConfig({
     },
 
     plugins: [
+        ejsPrecompile(),
         banner(bannerText),
         nodePolyfills({
             include: [], // Minimal polyfills
@@ -78,11 +79,7 @@ export default defineConfig({
         }),
     ],
 
-    define: {
-        global: 'globalThis', // For EJS compatibility
-    },
-
     optimizeDeps: {
-        include: ['ejs', 'jszip', '@xmldom/xmldom'],
+        include: ['jszip', '@xmldom/xmldom'],
     },
 });

--- a/vitest.config.js
+++ b/vitest.config.js
@@ -1,6 +1,8 @@
 import { defineConfig } from 'vitest/config';
+import { ejsPrecompile } from './vite-plugin-ejs-precompile.js';
 
 export default defineConfig({
+    plugins: [ejsPrecompile()],
     test: {
         globals: true,
         environment: 'happy-dom',


### PR DESCRIPTION
To reduce the size and the number of dependencies, compile the EJS templates to Javascript functions.