### PR TITLE
Fix 'notes.html' not found error

### DIFF
--- a/src/tpl/book.opf.ejs
+++ b/src/tpl/book.opf.ejs
@@ -24,7 +24,9 @@
 		    <item id="front-cover" href="OEBPS/front-cover.html" media-type="application/xhtml+xml" />
         <% } %>
 		<item id="title-page" href="OEBPS/title-page.html" media-type="application/xhtml+xml" />
-		<item id="notes" href="OEBPS/notes.html" media-type="application/xhtml+xml" />
+		<% if (data.notes) { %>
+			<item id="notes" href="OEBPS/notes.html" media-type="application/xhtml+xml" />
+		<% } %>
 		<item id="table-of-contents" href="OEBPS/table-of-contents.html" media-type="application/xhtml+xml" />
         <% data.pages.forEach((page, index) => { %>
             <item id="page-<%= index %>" href="OEBPS/page-<%= index %>.html" media-type="application/xhtml+xml" />


### PR DESCRIPTION
After using [EPUBCheck](https://www.w3.org/publishing/epubcheck/) and not setting the notes from a ePub, I notice that the file "OEBPS/notes.html" doesn't exists and is generating this error:
File "OEBPS/notes.html" could not be found.