### PR TITLE
Make param `attributes` optional for `jEpub.image` in index.d.ts

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -131,7 +131,7 @@ export default class jEpub {
      * @returns jEpub instance for method chaining
      * @throws Error if image data is invalid
      */
-    image(data: Blob | ArrayBuffer, name: string, attributes: Record<string, string>): this;
+    image(data: Blob | ArrayBuffer, name: string, attributes?: Record<string, string>): this;
 
     /**
      * Add notes page to the book


### PR DESCRIPTION
https://github.com/lelinhtinh/jEpub/blob/96c00beebfcaa67792802064c86a7b0c0cb3116c/src/jepub.js#L168-L176

https://github.com/lelinhtinh/jEpub/blob/96c00beebfcaa67792802064c86a7b0c0cb3116c/index.d.ts#L134

Fix: `attributes` is an optional param in `jepub.js` but required in `index.d.ts`.